### PR TITLE
Fix web version

### DIFF
--- a/main.js
+++ b/main.js
@@ -95,7 +95,7 @@ const run = async () => {
   let visualizationCanvas = document.getElementById('canvasImgmatch');
   let list = document.getElementById("itemlist");
   if (itemcounter === null) {
-    itemcounter = new ItemCounter(tmpCanvas, progressCb, "iconpacks", currentTemplate, visualizationCanvas, list);
+    itemcounter = new ItemCounter(tmpCanvas, progressCb, window.alert, "iconpacks", currentTemplate, visualizationCanvas, list);
     await itemcounter.init();
   }
   itemcounter.setFilter(await getFilter());


### PR DESCRIPTION
Adds missing error callback.

The web version is currently broken due to the ItemCounter constructor change in [c862ef9](https://github.com/pogobanane/foxhole-screenparse/commit/c862ef969d21516b039a97e838ce5e88b1c26749#diff-f1138e945fb2567182a09679b39f8ffdbc0b9d9852ed6624b9911e97f0497c5fL10-R10).